### PR TITLE
Add OpenAI headline helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-# React Multiply by 5 App
+# News Helper App
 
-This repository contains a small React example that multiplies an input number by 5.
+This repository contains small demos built with React.
 
-Open `index.html` in a browser to try it out.
+- `multiply.html` &ndash; multiplies an input number by 5.
+- `headline.html` &ndash; uses the OpenAI API to suggest headlines for pasted article text (requires your API key).
+- `index.html` &ndash; a landing page with links to the demos.
+
+Open any of the HTML files in a browser to try them out.

--- a/headline.html
+++ b/headline.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Headline Suggestion</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    function HeadlineApp() {
+      const [apiKey, setApiKey] = React.useState('');
+      const [article, setArticle] = React.useState('');
+      const [headlines, setHeadlines] = React.useState([]);
+      const [loading, setLoading] = React.useState(false);
+
+      async function generateHeadlines() {
+        if (!apiKey || !article) return;
+        setLoading(true);
+        try {
+          const response = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${apiKey}`
+            },
+            body: JSON.stringify({
+              model: 'gpt-3.5-turbo',
+              messages: [
+                { role: 'system', content: 'You are a helpful assistant that creates short, engaging news headlines.' },
+                { role: 'user', content: `Provide five headline or subheadline suggestions for the following article:\n\n${article}` }
+              ],
+              max_tokens: 150,
+              n: 1,
+              temperature: 0.7
+            })
+          });
+
+          if (!response.ok) {
+            throw new Error('API request failed');
+          }
+          const data = await response.json();
+          const text = data.choices[0].message.content.trim();
+          setHeadlines(text.split(/\n+/));
+        } catch (err) {
+          alert(err.message);
+        } finally {
+          setLoading(false);
+        }
+      }
+
+      return (
+        <div>
+          <h1>Headline Suggestion Tool</h1>
+          <p>Enter your OpenAI API key and paste the article text below.</p>
+          <input
+            type="password"
+            placeholder="OpenAI API Key"
+            value={apiKey}
+            onChange={e => setApiKey(e.target.value)}
+            style={{ width: '100%', marginBottom: '10px' }}
+          />
+          <textarea
+            rows="10"
+            style={{ width: '100%' }}
+            placeholder="Paste article text here"
+            value={article}
+            onChange={e => setArticle(e.target.value)}
+          />
+          <br />
+          <button onClick={generateHeadlines} disabled={loading}>
+            {loading ? 'Generating...' : 'Suggest Headlines'}
+          </button>
+          <ul>
+            {headlines.map((h, i) => (
+              <li key={i}>{h}</li>
+            ))}
+          </ul>
+          <p><a href="index.html">Back to home</a></p>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<HeadlineApp />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,32 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Multiply by 5</title>
-  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
-  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <title>News Helper</title>
 </head>
 <body>
-  <div id="root"></div>
-  <script type="text/babel">
-    function MultiplierApp() {
-      const [number, setNumber] = React.useState('');
-      const product = number === '' ? '' : Number(number) * 5;
-      return (
-        <div>
-          <h1>Multiply by 5</h1>
-          <input
-            type="number"
-            value={number}
-            onChange={e => setNumber(e.target.value)}
-            placeholder="Enter a number"
-          />
-          <p>Product: {product}</p>
-        </div>
-      );
-    }
-
-    ReactDOM.render(<MultiplierApp />, document.getElementById('root'));
-  </script>
+  <h1>News Helper App</h1>
+  <ul>
+    <li><a href="multiply.html">Multiply by 5 Demo</a></li>
+    <li><a href="headline.html">Headline Suggestion Tool</a></li>
+  </ul>
 </body>
 </html>

--- a/multiply.html
+++ b/multiply.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Multiply by 5</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    function MultiplierApp() {
+      const [number, setNumber] = React.useState('');
+      const product = number === '' ? '' : Number(number) * 5;
+      return (
+        <div>
+          <h1>Multiply by 5</h1>
+          <input
+            type="number"
+            value={number}
+            onChange={e => setNumber(e.target.value)}
+            placeholder="Enter a number"
+          />
+          <p>Product: {product}</p>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<MultiplierApp />, document.getElementById('root'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add landing page with links to demos
- include headline suggestion page using OpenAI API
- move original multiplier example to `multiply.html`
- update README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686593c44610832bb375735a74790af6